### PR TITLE
Fixed a typo

### DIFF
--- a/doc_source/working-with-predefined-recipes.md
+++ b/doc_source/working-with-predefined-recipes.md
@@ -8,7 +8,7 @@ The predefined recipes use the following during training:
 + Predefined algorithms 
 + Initial parameter settings for the algorithms
 
-To optimize your model, you can override many of these parameters when you create a soluton\. For more information, see [Hyperparameters and HPO](customizing-solution-config-hpo.md)\.
+To optimize your model, you can override many of these parameters when you create a solution\. For more information, see [Hyperparameters and HPO](customizing-solution-config-hpo.md)\.
 
 Amazon Personalize can automatically choose the most appropriate hierarchical recurrent neural network \(HRNN\) recipe based on its analysis of the input data\. This option is called AutoML\. To perform AutoML, set the `performAutoML` parameter to `true` when you call the [CreateSolution](API_CreateSolution.md) API\. Alternatively, you can choose a specific recipe based on what you want to accomplish and how famliar you are with the recipes\. Each recipe is designed for a specific use case\. When creating a solution, choose the recipe that best fits your needs\.
 


### PR DESCRIPTION
solution was misspelled as soluton

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
