### PR TITLE
url  changed for personalize_putEvents_demo.ipynb

### DIFF
--- a/doc_source/native-recipe-hrnn.md
+++ b/doc_source/native-recipe-hrnn.md
@@ -37,4 +37,4 @@ The table also provides the following information for each hyperparameter:
 
 The following Jupyter notebooks show how to use the HRNN recipe: 
 +  For a sample notebook that shows how to use HRNN with a hold\-out set, see [Amazon Personalize with temporal evaluation on hold\-out set](https://github.com/aws-samples/amazon-personalize-samples/blob/master/personalize_temporal_holdout/personalize_temporal_holdout.ipynb)\.
-+  For a sample notebook that shows how to use HRNN with the `PutEvents` API, see [Using the put events API with Amazon Personalize](https://github.com/aws-samples/amazon-personalize-samples/blob/master/personalize_temporal_holdout/personalize_putEvents_demo.ipynb)\.
++  For a sample notebook that shows how to use HRNN with the `PutEvents` API, see [Using the put events API with Amazon Personalize](https://github.com/aws-samples/amazon-personalize-samples/blob/master/advanced_examples/personalize_putEvents_demo.ipynb)\.


### PR DESCRIPTION
corrected url to reference new github location of notebook example for putEvents

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
