### PR TITLE
updated link to temporal holdout notebook

### DIFF
--- a/doc_source/working-with-training-metrics.md
+++ b/doc_source/working-with-training-metrics.md
@@ -91,4 +91,4 @@ Now that you have evaluated your solution version, create a campaign by deployin
 
 ## More Info<a name="metrics-see-also"></a>
 
-For a sample Jupyter notebook that shows you how to retrieve metrics based on hold\-out data, see [Personalize with Temporal Evaluation on Hold\-Out Set](https://github.com/aws-samples/amazon-personalize-samples/blob/master/advanced_examples/personalize_temporal_holdout.ipynb)\.
+For a sample Jupyter notebook that shows you how to retrieve metrics based on hold\-out data, see [Personalize with Temporal Evaluation on Hold\-Out Set](https://github.com/aws-samples/amazon-personalize-samples/blob/master/data_science/offline_performance_evaluation/personalize_temporal_holdout.ipynb)\.


### PR DESCRIPTION
link was to old location, edited link to new location of temporal holdout notebook https://github.com/aws-samples/amazon-personalize-samples/blob/master/data_science/offline_performance_evaluation/personalize_temporal_holdout.ipynb

*Issue #, if available:*

*Description of changes:*
Changed the link for temporal holdout from https://github.com/aws-samples/amazon-personalize-samples/blob/master/advanced_examples/personalize_temporal_holdout.ipynb to https://github.com/aws-samples/amazon-personalize-samples/blob/master/data_science/offline_performance_evaluation/personalize_temporal_holdout.ipynb which is the new location

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
