### PR TITLE
Fix closing quote

### DIFF
--- a/doc_source/customizing-solution-config-hpo.md
+++ b/doc_source/customizing-solution-config-hpo.md
@@ -15,7 +15,7 @@ A condensed version of the `CreateSolution` request is below\. The example inclu
   "eventType": "string",
   "solutionConfig": {
       "optimizationObjective": {
-          "itemAttribute": "string,
+          "itemAttribute": "string",
           "objectiveSensitivity": "string"
       }
       "autoMLConfig": {


### PR DESCRIPTION
Fix the closing quote to fix syntax highlighting

*Issue #, if available:*

*Description of changes:*
Fixing the closing quote in code example so the syntax highlighter works for the whole example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
